### PR TITLE
Bugfix for latdiff = 0 leading to NaN within estimate_longlatdiamkm

### DIFF
--- a/get_unique_craters.py
+++ b/get_unique_craters.py
@@ -131,6 +131,8 @@ def estimate_longlatdiamkm(dim, llbd, distcoeff, coords):
     # Iterative method for determining latitude.
     lat_deg_firstest = lat_central - deg_per_pix * (lat_pix - dim[1] / 2.)
     latdiff = abs(lat_central - lat_deg_firstest)
+    # Protect against latdiff = 0 situation.
+    latdiff[latdiff < 1e-7] = 1e-7
     lat_deg = lat_central - (deg_per_pix * (lat_pix - dim[1] / 2.) *
                              (np.pi * latdiff / 180.) /
                              np.sin(np.pi * latdiff / 180.))


### PR DESCRIPTION
Fixed using a limiter that takes advantage of the fact that:
```
assert (np.pi * latdiff / 180.) / np.sin(np.pi * latdiff / 180.) == 1
```
is true if `latdiff` is less than `1e-6`.

By the way, I suggest that we use either "squash and merge" (if you don't want to keep the commits in the branch) or "rebase and merge" (if you do, but don't want to clutter up the branch) from now on.